### PR TITLE
Fix invalid VOLUME syntax in upstream container

### DIFF
--- a/sqitch/Dockerfile
+++ b/sqitch/Dockerfile
@@ -1,8 +1,19 @@
-FROM matteofigus/docker-sqitch
+FROM perl:latest
 MAINTAINER Chef Software, Inc. <docker@chef.io>
 
-# Install pg_prove
-RUN apt-get install cpanminus -y && \
-  cpanm --quiet --notest TAP::Parser::SourceHandler::pgTAP
+RUN apt-get update && \
+    apt-get install cpanminus postgresql-client-common postgresql-client -y --no-install-recommends && \
+    apt-get clean
+
+# Install pg_prove after sqitch and perl postgres driver
+RUN cpanm --quiet --notest App::Sqitch && \
+    cpanm --quiet --notest DBD::Pg && \
+    cpanm --quiet --notest TAP::Parser::SourceHandler::pgTAP
 
 COPY ./wait-for-it.sh /wait-for-it.sh
+
+VOLUME ["/src"]
+WORKDIR /src
+
+CMD ["sqitch"]
+


### PR DESCRIPTION
According to Docker's docs, VOLUME syntax can either be a JSON array,
with the elements quoted, or a bare list of space separated items. The
upstream for the sqitch container is using some kind of in-between
syntax (`VOLUME [/src]`) which seems to cause problems on some versions
of Docker (I have `17.09.0-ce-mac35 (19611)` -- also note that you only see it when you modify certain things downstream).

Since the upstream doesn't actually do a whole lot (basically just
installs sqitch w/ cpan), I decided to inline it for expediency. This
also let me use `cpanm` to install sqitch which saves a lot of time when
rebuilding.

Signed-off-by: Daniel DeLeo <dan@chef.io>